### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
         "autoprefixer": "^10.4.16",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^1.2.0",
+        "laravel-vite-plugin": "^0.6.0",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.4.0",
-        "vite": "^6.0.11"
+        "vite": "^3.0.2"
     },
     "dependencies": {
         "bootstrap": "^5.3.3"

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,16 +8,4 @@ export default defineConfig({
             refresh: true,
         }),
     ],
-    build: {
-        outDir: 'public/build',
-    },
-    server: { // from https://github.com/laravel/framework/discussions/46928 JLB 20250320
-        port: 5173,
-        watch: {
-            ignored: [
-                '**/vendor/**', // <----- WORKS PERFECTLY
-                '**/storage/**', // <----- WORKS PERFECTLY
-            ],
-        },
-    },
 });


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-144642` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
